### PR TITLE
add cobra cli framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,15 +10,43 @@ Pratique is a service can be launched that reports the overall health of a clust
 
 ## Getting Started
 
-These instructions will get you a copy of the project up and running on your local machine for development and testing purposes. See deployment for notes on how to deploy the project on a live system.
+### CLI Prerequisites
 
-### Prerequisites
+* Golang installed
 
-WIP
+* Your $PATH configured:
+
+```
+$ export PATH=$GOROOT/bin:$GOPATH/bin:$PATH
+```
+
+### Download and run
+
+In order to use the command line, compile it using the following command:
+
+```
+$ go get github.com/jessicagreben/pratique
+```
+
+Build and install the program:
+
+```
+go install github.com/jessicagreben/pratique
+```
+
+`pratique` commands:
+
+To view details and available commands:
+
+```
+$ pratique help
+```
 
 ## Running the tests
 
-WIP
+```
+go test
+```
 
 ## Deployment
 
@@ -27,7 +55,7 @@ WIP
 ## Built With
 
 * [Cobra](https://github.com/spf13/cobra) - A Commander for modern Go CLI interactions
-* [Kubernetes Client-go](https://github.com/kubernetes/client-go) - Go client for Kubernetes.
+* [Kubernetes client-go](https://github.com/kubernetes/client-go) - Go client for Kubernetes.
 
 ## Contributing
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,0 +1,54 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	homedir "github.com/mitchellh/go-homedir"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var cfgFile string
+
+var rootCmd = &cobra.Command{
+	Use:   "pratique",
+	Short: "Reports on the overall health of a kubernetes cluster.",
+	Long: `Runs checks and reports on the overall health of a kubernetes cluster.`,
+	//	Run: func(cmd *cobra.Command, args []string) { },
+}
+
+func Execute() {
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+}
+
+func init() {
+	cobra.OnInitialize(initConfig)
+
+	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.pratiquetest.yaml)")
+}
+
+// initConfig reads in config file and ENV variables if set.
+func initConfig() {
+	if cfgFile != "" {
+		viper.SetConfigFile(cfgFile)
+	} else {
+		home, err := homedir.Dir()
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+
+		viper.AddConfigPath(home)
+		viper.SetConfigName(".pratiquetest")
+	}
+
+	viper.AutomaticEnv()
+
+	if err := viper.ReadInConfig(); err == nil {
+		fmt.Println("Using config file:", viper.ConfigFileUsed())
+	}
+}

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,23 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var Version = "v0.1.0"
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Print pratique version",
+	Run: getVersion,
+}
+
+func getVersion(cmd *cobra.Command, args []string) {
+	fmt.Println("Current API version:", Version)
+}
+
+func init() {
+	rootCmd.AddCommand(versionCmd)
+}

--- a/main.go
+++ b/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/jessicagreben/pratique/cmd"
+
+func main() {
+	cmd.Execute()
+}


### PR DESCRIPTION
- Used [cobra generator](https://github.com/spf13/cobra/blob/master/cobra/README.md) to create the API scaffolding for pratique. 
- Added a `version` command to print the current version of pratique.